### PR TITLE
fixed unwanted clock enable at start and when changing frequency; mad…

### DIFF
--- a/si5351_BA_VFO/si5351_BA_VFO.ino
+++ b/si5351_BA_VFO/si5351_BA_VFO.ino
@@ -198,9 +198,9 @@
 #define FREQ_VFO_B_MIN              7000000
 #define FREQ_VFO_B_MAX              7300000
 
-#define FREQ_VFO_C_DEFAULT         10120000
-#define FREQ_VFO_C_MIN             10100000
-#define FREQ_VFO_C_MAX             10150000
+#define FREQ_VFO_C_DEFAULT         14060000
+#define FREQ_VFO_C_MIN             14000000
+#define FREQ_VFO_C_MAX             14350000
 
 /**
  * delay times

--- a/si5351_BA_VFO/si5351_VFODefinition.h
+++ b/si5351_BA_VFO/si5351_VFODefinition.h
@@ -175,7 +175,10 @@ public:
                        ((unsigned long long)(((long long) frequency) + fixedFrequencyOffset))*SI5351_FREQ_MULT
                      , si5351Clock
       );
-#endif		   
+#endif	
+     // turn off clock at new freq	   
+     si5351.output_enable(si5351Clock, 0);
+     running = false;      
    }
 };
 


### PR DESCRIPTION
…e third default band 20m, better fit for pre-WARC boat anchors